### PR TITLE
phase2: harden CI, flatten repo, add pre-commit + nested-repo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,45 +2,36 @@ name: CI
 
 on:
   push:
-    branches: [ main, phase2-dev, phase2-fix ]
+    branches: [ main, phase2-dev ]
   pull_request:
     branches: [ main ]
-  schedule:
-    - cron: '17 8 * * *'  # daily at 08:17 UTC
 
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-latest
-    env:
-      PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/src
-    steps:
-      - uses: actions/checkout@v4
 
-      - name: Nested repo check
-        shell: bash
-        run: |
-          chmod +x scripts/check-nested-repos.sh
-          bash scripts/check-nested-repos.sh
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: requirements.txt
-
-      - name: Run pre-commit (all files)
-        run: |
-          python -m pip install --upgrade pip
-          pip install pre-commit
-          pre-commit run --all-files --show-diff-on-failure
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest
+          pip install pytest pre-commit
+
+      - name: Nested repo check
+        run: bash scripts/check-nested-repos.sh
+
+      - name: Run pre-commit (all files)
+        run: pre-commit run --all-files --show-diff-on-failure
 
       - name: Run pytest
         run: pytest -q tests --ignore=whisper
-git push -u origin HEAD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,4 @@ jobs:
 
       - name: Run pytest
         run: pytest -q tests --ignore=whisper
+git push -u origin HEAD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main, phase2-dev, phase2-fix ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '17 8 * * *'  # daily at 08:17 UTC
 
 jobs:
   tests:
@@ -14,12 +16,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Nested repo check
+        shell: bash
+        run: |
+          chmod +x scripts/check-nested-repos.sh
+          bash scripts/check-nested-repos.sh
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: requirements.txt
+
+      - name: Run pre-commit (all files)
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+          pre-commit run --all-files --show-diff-on-failure
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,45 +2,33 @@ name: CI
 
 on:
   push:
-    branches: [ main, phase2-dev, phase2-fix ]
+    branches: [ main, phase2-dev ]
   pull_request:
     branches: [ main ]
-  schedule:
-    - cron: '17 8 * * *'  # daily at 08:17 UTC
+  workflow_dispatch:
 
 jobs:
   tests:
     runs-on: ubuntu-latest
-    env:
-      PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/src
     steps:
       - uses: actions/checkout@v4
-
-      - name: Nested repo check
-        shell: bash
-        run: |
-          chmod +x scripts/check-nested-repos.sh
-          bash scripts/check-nested-repos.sh
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: requirements.txt
-
-      - name: Run pre-commit (all files)
-        run: |
-          python -m pip install --upgrade pip
-          pip install pre-commit
-          pre-commit run --all-files --show-diff-on-failure
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest
+          pip install pytest pre-commit
+
+      - name: Check for nested repos
+        run: bash scripts/check-nested-repos.sh
+
+      - name: Run pre-commit (all files)
+        run: pre-commit run --all-files --show-diff-on-failure
 
       - name: Run pytest
         run: pytest -q tests --ignore=whisper
-git push -u origin HEAD

--- a/scripts/check-nested-repos.sh
+++ b/scripts/check-nested-repos.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "::group::Nested Git repo check"
+
+# Find any ".git" dir/file that isn't the root .git
+mapfile -t offenders < <(find . -path "./.git" -prune -o -name ".git" -print | grep -vE '^./.git$' || true)
+
+if ((${#offenders[@]})); then
+  echo "Found nested Git repo markers (.git) in the tree:"
+  for p in "${offenders[@]}"; do
+    # Strip trailing "/.git" for readability
+    echo " - ${p%/.git}"
+  done
+  echo "::error title=Nested repo(s) detected::Remove these nested repos or vendor them without their .git dirs."
+  exit 1
+else
+  echo "No nested Git repos found."
+fi
+
+echo "::endgroup::"


### PR DESCRIPTION
Summary

Phase 2 hardening: flatten repo, add reliable CI, and prevent nested Git repos from reappearing. Also tidies test collection and moves adapters to a canonical location.

Why
	•	Nested repos silently break Git history and CI.
	•	Vendored/duplicated code made imports and testing flaky.
	•	CI needed a consistent, minimal path that runs quickly and fails fast.

What changed
	•	Repo hygiene
	•	Removed nested repo(s) and vendored whisper/.
	•	Added ignores for third-party sources and nested .git dirs.
	•	Added scripts/check-nested-repos.sh.
	•	Pre-commit
	•	Added .pre-commit-config.yaml.
	•	Hook runs the nested-repo check and a quick smoke test on commit.
	•	CI
	•	New workflow: .github/workflows/ci.yml (Python 3.11).
	•	Steps: checkout → pre-commit (all files) → install deps → pytest -q tests --ignore=whisper.
	•	Optional nightly schedule for nested-repo check.
	•	Testing
	•	pytest.ini: limit discovery to tests/, ignore whisper/ and PennyGPT-Project/.
	•	Structure
	•	Moved adapters to top-level adapters/:
	•	cloud_openai_adapter.py
	•	local_ollama_adapter.py
	•	whisper_adapter.py
	•	google_tts_adapter.py
	•	Minor core/personality cleanups; exposed load_config in llm_router.

How to test
pip install -r requirements.txt
pre-commit install && pre-commit run --all-files
pytest -q tests --ignore=whisper

Reviewer notes
	•	Verify no nested .git/ directories remain.
	•	Confirm CI shows pre-commit + pytest and that test discovery only hits tests/.
	•	Sanity-check adapter import paths after the move.

Follow-ups (separate PRs)
	•	Add formatting/linters to pre-commit (ruff/black).
	•	Expand unit tests beyond smoke.
	•	Decide whether to keep the scheduled nightly nested-repo check.