### PR TITLE
Fix CI: scope PyObjC deps to macOS only (platform_system == Darwin)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -126,22 +126,22 @@ pygments==2.19.2
     # via pytest
 pynput==1.8.1
     # via -r requirements.in
-pyobjc-core==11.1
+pyobjc-core==11.1; platform_system == "Darwin"
     # via
     #   pyobjc-framework-applicationservices
     #   pyobjc-framework-cocoa
     #   pyobjc-framework-coretext
     #   pyobjc-framework-quartz
-pyobjc-framework-applicationservices==11.1
+pyobjc-framework-applicationservices==11.1; platform_system == "Darwin"
     # via pynput
-pyobjc-framework-cocoa==11.1
+pyobjc-framework-cocoa==11.1; platform_system == "Darwin"
     # via
     #   pyobjc-framework-applicationservices
     #   pyobjc-framework-coretext
     #   pyobjc-framework-quartz
-pyobjc-framework-coretext==11.1
+pyobjc-framework-coretext==11.1; platform_system == "Darwin"
     # via pyobjc-framework-applicationservices
-pyobjc-framework-quartz==11.1
+pyobjc-framework-quartz==11.1; platform_system == "Darwin"
     # via
     #   pynput
     #   pyobjc-framework-applicationservices


### PR DESCRIPTION
## Problem

The Ubuntu CI matrix was failing at the `pip install -r requirements.txt` step:

```
PyObjC requires macOS to build
```

Five PyObjC packages were listed unconditionally in `requirements.txt`:
`pyobjc-core`, `pyobjc-framework-applicationservices`, `pyobjc-framework-cocoa`,
`pyobjc-framework-coretext`, `pyobjc-framework-quartz` (all `==11.1`). These have
no Linux wheels and fail to build on Linux. They come in **transitively via
`pynput`** (the compile ran on macOS, so the lockfile captured the macOS-only branch).

## Fix

Added an environment marker to those 5 lines so they only install on macOS:

```
pyobjc-core==11.1; platform_system == "Darwin"
```

**Only `requirements.txt` changed — 5 lines, markers added. Nothing else.**

## Why no import guards were needed

- There are **no direct PyObjC imports** anywhere in the codebase (only a string
  mention in one test).
- `pynput` is **cross-platform** — it uses X11 (`python-xlib`) on Linux and does
  **not** require PyObjC to import there.
- The only importer of `pynput` is `penny.py`, which **is not imported by any
  test**, so it never loads during the CI `pytest` run. Nothing needed guarding.

## Verification

Evaluated each PyObjC line's marker with `packaging` (the same evaluator pip uses),
simulating both platforms:
- **Linux (Ubuntu CI):** all 5 excluded — and they are the *only* packages excluded.
- **macOS:** all 5 still included — local dev unaffected.

`requirements.txt` still parses cleanly (no malformed lines).

## Known follow-up (not fixing here)

`requirements.txt` is **pip-compile-generated**, and PyObjC is transitive (via
`pynput`), so a future `pip-compile` would regenerate these lines **without** the
markers and silently reintroduce the failure. Worth addressing at the
`requirements.in` / compile level later — flagging as a follow-up, out of scope
for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
