### PR TITLE
Fix CI: declare psutil dependency (was missing, unguarded imports crash)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,3 +16,4 @@ uvicorn[standard]>=0.24.0
 pydantic>=2.0.0
 httpx
 docker>=7.0.0
+psutil  # used by operational-security modules (multi_channel_emergency_stop, rate_limiting_resource_control)

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,6 +111,8 @@ propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
+psutil==7.1.0
+    # via -r requirements.in
 pycparser==2.22
     # via cffi
 pydantic==2.11.7


### PR DESCRIPTION
## Problem

The `think()` characterization tests (`tests/test_pipeline_characterization.py`,
`tests/test_pipeline_characterization_extended.py`) — the exact tests meant to gate
the R1 `think()` decomposition — fail at **collection** in CI:

```
NameError: name 'MultiChannelEmergencyStop' is not defined
```

## Root cause

`psutil` is imported **unguarded** in four production modules
(`multi_channel_emergency_stop.py`, `rate_limiting_resource_control.py`,
`lm_studio_performance_monitor.py`, `runaway_process_detector.py`) but was
**never declared** as a dependency in `requirements.txt`/`requirements.in`. It
happened to be installed locally, so this only reproduced in CI's fresh install.

When psutil is absent, `mcp_protocol_foundation.py`'s security-import block fails:

```python
try:
    from multi_channel_emergency_stop import MultiChannelEmergencyStop, EmergencyTrigger  # imports psutil
    ...
except ImportError as e:
    print(f"Warning: Could not import security components: {e}")
```

The `except` swallows the error, but the names are then used **unconditionally**
below (type annotations at lines 492-493, factory helpers), so the module raises
`NameError` at import — which cascades to the test collection failure.

## Fix

Declare `psutil` as the genuine dependency it is:
- `requirements.txt`: `psutil==7.1.0` (`# via -r requirements.in`)
- `requirements.in`: `psutil` (so a future `pip-compile` preserves it)

**Only these two files changed.** No source changes.

## Attempted guard-fix, and why it was reverted

I first tried to make the `try/except` degrade gracefully by defining `None`
fallbacks in the `except` block. That **doesn't work**: `mcp_protocol_foundation.py`
lines 150-151 use enum values as **import-time dataclass field defaults**:

```python
security_risk: SecurityRisk = SecurityRisk.MEDIUM
operation_type: OperationType = OperationType.RESTRICTED
```

With `None` fallbacks this just turns the `NameError` into
`AttributeError: 'NoneType' object has no attribute 'MEDIUM'`. Truly handling
absence would require stub enums throughout the module — and structurally the
module genuinely requires the security stack. So the fallback edit was reverted;
the module is unchanged.

## Verification

- ✅ **17/17** — `pytest tests/test_pipeline_characterization.py tests/test_pipeline_characterization_extended.py --run-slow` collects and passes (matches PR #5).
- ✅ **451** — canonical `make test` unaffected.
- ✅ Wheel compatibility — `psutil==7.1.0` ships a `cp36-abi3` wheel (stable ABI; works on 3.11 and 3.13; `requires_python >=3.6`). Fresh-venv dry-run confirmed it resolves.

## Known caveat / follow-up (not in this PR)

This ensures psutil is **always installed** so the crash can't happen. It does
**not** make `mcp_protocol_foundation.py`'s `try/except` actually handle a missing
security dependency — that guard remains non-functional. Making absence gracefully
handled (stub enums / restructured dataclass defaults) is a separate, larger
refactor, flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
