### PR TITLE
Fix clean install: declare sentence-transformers, faiss-cpu, cryptography (+ cffi/setuptools consistency)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,3 +17,7 @@ pydantic>=2.0.0
 httpx
 docker>=7.0.0
 psutil  # used by operational-security modules (multi_channel_emergency_stop, rate_limiting_resource_control)
+cryptography  # used by src/security/encryption.py (Fernet)
+faiss-cpu  # `import faiss` in src/memory/vector_store.py
+sentence-transformers  # used by src/memory/embedding_generator.py
+setuptools<81  # webrtcvad imports pkg_resources, removed in setuptools 81+

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,9 @@ certifi==2025.8.3
     #   httpcore
     #   httpx
     #   requests
-cffi==1.17.1
+cffi==2.0.0
     # via
+    #   cryptography
     #   sounddevice
     #   soundfile
 charset-normalizer==3.4.3
@@ -35,12 +36,16 @@ click==8.1.8
     # via
     #   gtts
     #   uvicorn
+cryptography==46.0.3
+    # via -r requirements.in
 distro==1.9.0
     # via openai
 docker==7.1.0
     # via -r requirements.in
 docker-pycreds==0.4.0
     # via docker
+faiss-cpu==1.12.0
+    # via -r requirements.in
 fastapi==0.116.1
     # via -r requirements.in
 filelock==3.19.1
@@ -163,6 +168,11 @@ requests==2.32.4
     #   -r requirements.in
     #   gtts
     #   tiktoken
+sentence-transformers==5.1.2
+    # via -r requirements.in
+setuptools<81
+    # via -r requirements.in
+    # (webrtcvad imports pkg_resources, which setuptools 81+ removed)
 six==1.17.0
     # via pynput
 sniffio==1.3.1


### PR DESCRIPTION
## Problem

From a genuinely clean install (no locally-cached packages), the `think()`
characterization tests (`tests/test_pipeline_characterization.py`,
`tests/test_pipeline_characterization_extended.py`) can't collect. Three more
production dependencies are imported **unguarded** but were never declared —
same pattern as the psutil fix (#9). They only "worked" locally because they
happened to already be installed.

## The three dependencies (each confirmed genuinely required)

| Package | Imported by | Use |
|---|---|---|
| `sentence-transformers==5.1.2` | `src/memory/embedding_generator.py` | `SentenceTransformer` — embedding generation |
| `faiss-cpu==1.12.0` | `src/memory/vector_store.py` | `import faiss` — vector index (PyPI pkg is `faiss-cpu`) |
| `cryptography==46.0.3` | `src/security/encryption.py` | `Fernet` — field encryption |

All are core to the always-constructed semantic-memory / encryption stack — not
optional, so no import guards are warranted.

## Two transitive-consistency fixes the clean install required

Adding the above to the pip-compile lockfile surfaced two conflicts that had to
be resolved for a clean install to succeed:

- **`cffi==1.17.1` → `cffi==2.0.0`** — `cryptography 46.0.3` requires
  `cffi>=2.0.0`; the stale pin caused `ResolutionImpossible`. `2.0.0` is what's
  already installed locally, and `sounddevice`/`soundfile` (its other consumers)
  work with it.
- **`setuptools<81`** — the clean install pulled `setuptools 83` (transitively,
  via torch), which **removed `pkg_resources`**. `webrtcvad` still imports
  `pkg_resources`, so collection failed with `ModuleNotFoundError: No module
  named 'pkg_resources'`. Capping `<81` keeps `pkg_resources` available. **This
  is a temporary fix** — the real long-term follow-up is updating or replacing
  `webrtcvad` (it's unmaintained and relies on a deprecated setuptools API);
  flagging that as a separate item, out of scope here.

## Verification (truly clean environment)

```
python -m venv /tmp/clean-test-env
/tmp/clean-test-env/bin/pip install --no-cache-dir -r requirements.txt
```

- ✅ Install succeeds — **0 dependency conflicts**, `pkg_resources` present.
- ✅ **17/17** — `pytest tests/test_pipeline_characterization.py tests/test_pipeline_characterization_extended.py --run-slow` collects and passes from that clean install.
- ✅ **451** — canonical `make test` unaffected.

Only `requirements.in` and `requirements.txt` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
