### PR TITLE
CI: run canonical test suite (respect pytest.ini testpaths, not pytest tests/)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,13 @@ jobs:
         PENNY_DISABLE_HEALTH_LOOP: 1
         PYTHONPATH: src
       run: |
-        pytest tests/ -v --cov=src --cov-report=xml --cov-report=term-missing
+        # NOTE: no positional path argument on purpose.
+        # pytest only honors `testpaths` in pytest.ini when NO path/file is
+        # passed on the command line. `testpaths` defines the curated canonical
+        # suite (22 files) — the same set `make test` runs. Passing `tests/`
+        # here would OVERRIDE testpaths and collect all ~136 files, including
+        # quarantined/legacy ones that never pass in CI. Do not add `tests/`.
+        pytest -v --cov=src --cov-report=xml --cov-report=term-missing
     
     - name: Run Penny Doctor health check
       env:


### PR DESCRIPTION
## Problem

The `test` job ran:

```
pytest tests/ -v --cov=src --cov-report=xml --cov-report=term-missing
```

`pytest` only honors `testpaths` in `pytest.ini` **when no path/file argument is
given on the command line**. Passing the positional `tests/` **overrides
`testpaths` entirely**, so CI was collecting **all 136 files** under `tests/` —
including the stale/legacy/quarantined ones that were deliberately excluded from
the canonical suite — instead of the intended **22-file canonical suite**.

That's why CI kept failing on files like `test_conversation_telemetry.py`,
`test_mcp_integration.py`, `test_numpy_concat.py`, and
`test_phase_c_intelligence_integration.py` — none of which are in `testpaths`,
and none of which local `make test` ever ran. (Locally, `pytest tests/` doesn't
even collect cleanly — a legacy module segfaults during collection.)

## Fix

Drop the positional `tests/` so `testpaths` takes effect — the exact mechanism
`make test` already relies on:

```
pytest -v --cov=src --cov-report=xml --cov-report=term-missing
```

Added a comment above the line explaining *why* there's no path argument, so it
doesn't get "helpfully" changed back to `pytest tests/` by someone unaware of the
`testpaths` interaction.

## Verification (local)

Running the exact new command:
- **22 files collected** (matches `pytest.ini` `testpaths` and `make test`) — vs 136 with the old `tests/` form.
- **451 passed** in ~2.5s.

## Notes

- This is **config only** — one line in `.github/workflows/ci.yml` (plus comment).
- It's the correct alternative to chasing undeclared dependencies (`aiosqlite`,
  `pandas`, PortAudio, …) across the entire legacy test corpus: those failures
  were only happening because CI was running files that were never meant to be in
  the green suite. Aligning CI to the canonical suite removes that whole class of
  failure. (The separate dependency PRs #9/#10 remain valid — those deps are
  genuinely needed by code the canonical suite *does* exercise.)
- Coverage numbers will now reflect the canonical suite only; that's expected and
  consistent with what the project treats as its real, green test set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
