### PR TITLE
CI: fix TTS cache test path (moved to tests/ during cleanup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       env:
         PYTHONPATH: src
       run: |
-        python test_tts_cache.py
+        python tests/test_tts_cache.py
 
   integration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The **Test TTS cache system** CI step runs `python test_tts_cache.py`, but the file was moved to `tests/test_tts_cache.py` during commit `c8a0ea9` ("Repository cleanup before Week 8.5") and ci.yml was never updated — so the step fails with "No such file or directory". This is pre-existing on `main`, unrelated to any recent dependency work.

**Fix:** update the path to `python tests/test_tts_cache.py`. One line.

**Verified locally:** `PYTHONPATH=src python3 tests/test_tts_cache.py` -> **3/3 tests passed, exit 0**. (There are two non-fatal internal warnings about `GoogleTTS.speak()` and an `output_file` kwarg; the test handles them and still passes — a separate latent issue, left untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)