### PR TITLE
R1 step 1: extract financial disclaimer into a pure function

### DIFF
--- a/research_first_pipeline.py
+++ b/research_first_pipeline.py
@@ -88,6 +88,28 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _apply_financial_disclaimer(response: str, financial_topic: bool) -> str:
+    """Append Penny's financial disclaimer when responding on a financial topic.
+
+    Pure function: depends only on its two arguments (plus the module-level,
+    pure ``sanitize_output`` helper). No side effects, no ``self``/instance
+    state. Behavior is identical to the inline logic it replaces:
+      - non-financial topics are returned unchanged
+      - responses that already mention "disclaimer" / "financial advice" are
+        left as-is (no double disclaimer)
+      - otherwise the disclaimer is appended and the result is sanitized
+    """
+    if not financial_topic:
+        return response
+    if "disclaimer" in response.lower() or "financial advice" in response.lower():
+        return response
+    penny_disclaimer = (
+        "\n\nQuick note: I'm sharing general information here, not financial advice. "
+        "Talk to a licensed professional before making money moves."
+    )
+    return sanitize_output(response + penny_disclaimer)
+
+
 class ResearchFirstPipeline(PipelineLoop):
     """Research-first pipeline that always researches before answering factual questions."""
 
@@ -825,14 +847,7 @@ class ResearchFirstPipeline(PipelineLoop):
                 logger.debug("🧪 A/B Test: Skipping response post-processing (control group)")
 
             # Step 6: Add financial disclaimer if needed (in Penny's style)
-            if financial_topic:
-                # Check if we already have a disclaimer
-                if "disclaimer" not in final_response.lower() and "financial advice" not in final_response.lower():
-                    penny_disclaimer = (
-                        "\n\nQuick note: I'm sharing general information here, not financial advice. "
-                        "Talk to a licensed professional before making money moves."
-                    )
-                    final_response = sanitize_output(final_response + penny_disclaimer)
+            final_response = _apply_financial_disclaimer(final_response, financial_topic)
 
             # Step 8: Store in memory (WEEK 7: Dual-save architecture)
             try:


### PR DESCRIPTION
**R1 step 1 of the think() decomposition plan** — starting with the smallest, zero-coupling, fully-covered phase to prove the extract-and-stay-green loop before anything more entangled.

### Change
Moves the inline "Step 12" financial-disclaimer logic (~8 lines in `think()`) into a module-level pure function:

```python
def _apply_financial_disclaimer(response: str, financial_topic: bool) -> str: ...
```

`think()` now just calls it. **Pure refactor — no behavior change.**

### Purity
- Depends only on its two params (plus the module-level, pure `sanitize_output`).
- `co_freevars` is empty (no captured state); no `self`/instance access; no side effects.
- Logic is the exact same, De-Morgan-equivalent condition (`not A and not B` -> early-return on `A or B`).

### Verification
- **Behavioral equivalence:** new fn checked against the original inline logic across 7 input cases (financial T/F, pre-existing "disclaimer"/"financial advice", empty, stub) -> identical output for all.
- **17/17** characterization tests (`tests/test_pipeline_characterization*.py --run-slow`) — unchanged.
- **451** canonical `make test` — unaffected.

Per the R1 plan, the disclaimer belongs with response finalization (ResponseGenerator), not PostTurnProcessor — noted for the later composition step. Next up: PromptBuilder (the `llm_generator` closure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)