### PR TITLE
R1 step 2 prep: PromptBuilder coverage gaps + research_result init

### DIFF
--- a/research_first_pipeline.py
+++ b/research_first_pipeline.py
@@ -605,6 +605,8 @@ class ResearchFirstPipeline(PipelineLoop):
 
             # Step 3: Conduct research if needed
             research_context = ""
+            research_result = None  # ensure defined even when research isn't run
+                                    # (R1 PromptBuilder prep: becomes an explicit arg)
             if research_required:
                 logger.info("📚 Conducting research...")
                 research_result = self.research_manager.run_research(actual_command, [])

--- a/tests/test_pipeline_characterization_extended.py
+++ b/tests/test_pipeline_characterization_extended.py
@@ -335,3 +335,52 @@ class TestThinkKnownQuirks:
 
         assert p._last_response_id is None
         assert p._last_response_type is None
+
+
+class TestThinkPromptCaptureCoverage:
+    """
+    Closes coverage gaps found in the PromptBuilder pre-flight (R1 step 2 prep).
+    Several variables the `llm_generator` closure captures had no assertion on
+    their effect on the assembled prompt / LLM call, so a faithful extraction
+    could drop them without any test noticing. These lock the CURRENT behavior.
+    Nothing is extracted yet -- they exercise the closure exactly as it stands.
+    """
+
+    def test_tone_is_threaded_through_to_llm_call(self, pipeline):
+        # tone comes from _route_tone() (on the parent PipelineLoop) and must
+        # reach self.llm.complete(final_prompt, tone=tone). The existing tests
+        # record (prompt, tone) but never assert the tone slot.
+        p, _ = pipeline
+        p._route_tone = lambda text: "sentinel_tone"
+        p.state = State.THINKING
+        p.think("Hello Penny")
+
+        assert p.llm.calls, "LLM was never called"
+        assert p.llm.calls[0][1] == "sentinel_tone"
+
+    def test_conversation_and_semantic_sections_injected_when_present(self, pipeline):
+        # The existing 17 tests run on a fresh pipeline where conversation
+        # context and semantic results are both empty, so those two prompt
+        # sections are never exercised. Seed both and assert they land.
+        p, _ = pipeline
+        p.context_manager.get_context_for_prompt = lambda **kw: "PRIOR_CONTEXT_SENTINEL"
+        p.semantic_memory.semantic_search = lambda query, k=3: [
+            {"user_input": "we talked about widgets before", "similarity": 0.88},
+        ]
+        p.state = State.THINKING
+        p.think("Hello Penny")
+
+        prompt = p.llm.calls[0][0]
+        assert "PRIOR_CONTEXT_SENTINEL" in prompt                 # conversation-context section
+        assert "Relevant past conversations:" in prompt           # semantic-memory section header
+        assert "we talked about widgets before" in prompt         # semantic hit content
+
+    def test_current_emotion_line_injected(self, pipeline):
+        # emotion_result is always produced; its "User's current emotion:" line
+        # is injected into the prompt, but no existing test asserts it.
+        p, _ = pipeline
+        p.state = State.THINKING
+        p.think("Hello Penny, how are you today?")
+
+        prompt = p.llm.calls[0][0]
+        assert "User's current emotion:" in prompt


### PR DESCRIPTION
**Prep work for R1 step 2 (PromptBuilder extraction) — no extraction happens here.** Closes characterization coverage gaps and adds one safety init so the `llm_generator` closure can be lifted cleanly next.

### Step 1 — one-line safety init (production)
`research_result = None` before the `if research_required:` block. It is currently only assigned *inside* that block; safe today (only read via `_build_research_instructions`, which early-returns when research is off), but it must be defined unconditionally once it becomes an explicit parameter of the extracted PromptBuilder. Behavioral no-op.

### Step 2 — 3 additive characterization tests (current behavior)
The pre-flight found 5 captured variables whose effect on the assembled prompt / LLM call was never asserted (the existing 17 tests only run on a fresh/empty pipeline). These lock the current behavior so the extraction cannot silently drop them:
1. **`tone` threading** — asserts the tone from `_route_tone()` reaches `self.llm.complete(..., tone=tone)` (FakeLLM records it but nothing asserted the slot).
2. **conversation-context + semantic-memory sections** — seeds a prior context string and a semantic hit, asserts both prompt sections appear (previously always empty in tests).
3. **`User's current emotion:` line** — asserts the emotion line is injected.

### Verification
- **20/20** characterization tests (`--run-slow`) — 17 existing + 3 new.
- **451** canonical `make test` — unaffected.
- Production change is 2 lines; independent of PR #15 (P12), merges cleanly.

Next (separate PR after review/merge): the actual PromptBuilder lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)