### PR TITLE
R1 step 4: extract JudgmentGate (_judgment_gate)

### DIFF
--- a/research_first_pipeline.py
+++ b/research_first_pipeline.py
@@ -728,6 +728,40 @@ class ResearchFirstPipeline(PipelineLoop):
             research_result=research_result,
         )
 
+    def _judgment_gate(self, actual_command: str) -> Optional[str]:
+        """Judgment/clarify gate. Builds the judgment context (incl. the Fix-4a
+        belief injection) and asks _should_clarify whether to interrupt the turn.
+
+        Returns the clarifying-question string if clarification is needed,
+        else None. The caller (think()) sets state and returns early on a non-None
+        result, so the short-circuit stays visible in think()'s own body.
+        (_should_clarify / _log_judgment_decision are unchanged; the latter still
+        writes self.last_judgment_result + judgment_logs.jsonl as before.)
+        """
+        # Build initial context for judgment
+        initial_judgment_context = {
+            'conversation_history': [],  # Will populate from context manager
+            'semantic_memory': [],
+            'emotional_state': None,
+            'personality_state': None
+        }
+
+        # Fix 4a: give Judgment the user's relevant beliefs so it can reason
+        # about (and later flag contradictions against) what we already know.
+        if getattr(self, "belief_extractor", None) and self.user_model_enabled:
+            try:
+                kw = [w.strip(".,!?;:'\"").lower()
+                      for w in actual_command.split() if len(w) > 3]
+                initial_judgment_context['user_beliefs'] = (
+                    belief_integration.beliefs_for_judgment(self.belief_extractor, kw)
+                )
+            except Exception as jb_e:
+                logger.warning(f"Belief→judgment context failed (non-fatal): {jb_e}")
+
+        # Check if we should clarify before proceeding
+        should_clarify, clarifying_question = self._should_clarify(actual_command, initial_judgment_context)
+        return clarifying_question if should_clarify else None
+
     def think(self, user_text: str) -> str:
         """Research-first think method with comprehensive error handling."""
         if self.state.name != "THINKING":
@@ -797,34 +831,12 @@ class ResearchFirstPipeline(PipelineLoop):
                     logger.warning(f"Belief extraction error (non-fatal): {um_e}")
 
             # Step 1.3: Week 8.5 - Judgment check (should we clarify first?)
-            # Build initial context for judgment
-            initial_judgment_context = {
-                'conversation_history': [],  # Will populate from context manager
-                'semantic_memory': [],
-                'emotional_state': None,
-                'personality_state': None
-            }
-
-            # Fix 4a: give Judgment the user's relevant beliefs so it can reason
-            # about (and later flag contradictions against) what we already know.
-            if getattr(self, "belief_extractor", None) and self.user_model_enabled:
-                try:
-                    kw = [w.strip(".,!?;:'\"").lower()
-                          for w in actual_command.split() if len(w) > 3]
-                    initial_judgment_context['user_beliefs'] = (
-                        belief_integration.beliefs_for_judgment(self.belief_extractor, kw)
-                    )
-                except Exception as jb_e:
-                    logger.warning(f"Belief→judgment context failed (non-fatal): {jb_e}")
-
-            # Check if we should clarify before proceeding
-            should_clarify, clarifying_question = self._should_clarify(actual_command, initial_judgment_context)
-
-            if should_clarify:
+            clarification = self._judgment_gate(actual_command)
+            if clarification is not None:
                 # Return clarifying question instead of processing
                 logger.info(f"✋ Judgment system returned clarification - not proceeding with tools")
                 self.state = State.SPEAKING
-                return clarifying_question
+                return clarification
 
             # Step 1.5: Week 6 - Detect emotion from user input
             emotion_result = self.emotion_detector.detect_emotion(actual_command)


### PR DESCRIPTION
**R1 step 4 of the think() decomposition.** Wraps the judgment/clarify context-building block into a method; the short-circuit stays visible in `think()`. Pure, byte-for-byte faithful move.

### What moved (Option A, per the pre-flight)
- New method **`_judgment_gate(self, actual_command: str) -> Optional[str]`** containing exactly the current context-building block: `initial_judgment_context`, the Fix-4a belief injection (only if `belief_extractor` + `user_model_enabled`), and the `_should_clarify(...)` call. Returns the clarifying question if `should_clarify`, else `None`.
- `think()` now does:
  ```python
  clarification = self._judgment_gate(actual_command)
  if clarification is not None:
      logger.info("✋ Judgment system returned clarification - not proceeding with tools")
      self.state = State.SPEAKING
      return clarification
  ```
  The **state-set + return stay in `think()`** so the interrupt is explicit in the orchestrator body, not hidden in the gate.

### Untouched / preserved
- **`_should_clarify` and `_log_judgment_decision` are byte-identical** (verified via diff). `_log_judgment_decision` still writes `self.last_judgment_result` + appends `judgment_logs.jsonl`, exactly as before — the gate just calls `_should_clarify`, so those side effects are preserved automatically.
- **`is not None`** (not truthiness): equivalent to the old `if should_clarify` given `_should_clarify`'s contract (`(True, str)` or `(False, None)`); avoids treating an empty-string question as "proceed."
- Ordering unchanged: the gate is still Step 1.3, upstream of ResearchProcessor (#18) and PromptBuilder (#17) — on a clarify turn neither runs and `self.last_research_*` stay untouched, exactly as today.

### Verification
- **Byte-for-byte diff**: moved context-building block == original (22 lines, dedented); `_should_clarify`/`_log_judgment_decision` unchanged.
- **20/20** characterization (`--run-slow`), incl. the 3 judgment tests (`vague_referent_short_circuits`, `clarify_logs_duplicate_line`, `judgment_context_never_reflects_conversation_history`).
- **451** canonical `make test`.

One file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
