### PR TITLE
📝 Doc: session-end marker — Phase 5 Week 14 next

### DIFF
--- a/NEXT_PHASE_TASKS.md
+++ b/NEXT_PHASE_TASKS.md
@@ -15,6 +15,8 @@
 
 ## 🎯 QUICK STATUS
 
+**⏭️ Session ended August 25, 2026 — Phase 5 Week 14 (Platform Abstraction Layer) starts next session.**  
+
 **Current:** Phase 4 COMPLETE — R1 `think()` decomposition COMPLETE (6 phases, PRs #15–#23)  
 **Next:** Phase 5 begins — Week 14 (Platform Abstraction Layer), then Week 15 (Capability Awareness). R4/R5/R2 remain in Week 16  
 **Phase 4:** ✅ 100% Complete  


### PR DESCRIPTION
Docs-only. Adds a one-line session-end marker at the top of QUICK STATUS:

> **⏭️ Session ended August 25, 2026 — Phase 5 Week 14 (Platform Abstraction Layer) starts next session.**

Nothing else changed — R1/R4/R5 are already accurately recorded (PRs #24, #25).

No rush — review whenever. Do not merge on my account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
