### PR TITLE
🔊 Phase 5 Week 14: cross-platform audio-output abstraction (first slice)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -34,6 +34,7 @@ testpaths =
     tests/test_user_model_integration.py
     tests/test_user_model_enhancements.py
     tests/test_llm_registry.py
+    tests/test_audio_playback.py
 
 # Per-test timeout so a hung test (network/audio/LLM) can't stall the whole suite.
 # 'signal' method (vs 'thread') can interrupt blocking syscalls like a live

--- a/src/adapters/audio/__init__.py
+++ b/src/adapters/audio/__init__.py
@@ -1,0 +1,1 @@
+# Audio adapters (cross-platform playback primitives)

--- a/src/adapters/audio/playback.py
+++ b/src/adapters/audio/playback.py
@@ -1,0 +1,64 @@
+"""Cross-platform audio-output primitives (Phase 5 Week 14, first slice).
+
+Centralizes the OS-specific playback command that the TTS adapters previously
+hardcoded as ``["afplay", <file>]``. The adapters emit **MP3**, so every
+platform's command must be MP3-capable — ``afplay`` (macOS), ``mpg123`` (Linux),
+``ffplay`` (Windows) — NOT a PCM/WAV-only tool like ``aplay``/``paplay``/
+``winsound``.
+
+Failure model (two tiers):
+  * **Unknown platform** -> ``build_playback_command`` raises
+    ``UnsupportedPlatformError`` (loud), so a missing port is obvious during
+    development rather than a silent mute.
+  * **Known platform, player binary missing** -> a runtime ``FileNotFoundError``
+    at ``subprocess`` time, which callers already catch and degrade to silence.
+
+The interruptible TTS adapters call ``build_playback_command`` directly (keeping
+their own Popen/poll/terminate barge-in logic); ``play_audio_file`` is a thin
+blocking convenience for simple callers.
+"""
+import platform
+import subprocess
+from typing import List
+
+
+class UnsupportedPlatformError(RuntimeError):
+    """Raised when no audio playback command is defined for the host platform."""
+
+
+def build_playback_command(file_path: str) -> List[str]:
+    """Return the platform-appropriate argv to play an MP3 ``file_path``.
+
+    Raises ``UnsupportedPlatformError`` (naming the unresolved
+    ``platform.system()`` value) for any platform without a defined command.
+    """
+    system = platform.system()
+    if system == "Darwin":
+        return ["afplay", file_path]
+    if system == "Linux":
+        return ["mpg123", "-q", file_path]
+    if system == "Windows":
+        return ["ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet", file_path]
+    raise UnsupportedPlatformError(
+        f"No audio playback command defined for platform: {system!r}"
+    )
+
+
+def play_audio_file(file_path: str) -> bool:
+    """Blocking convenience: play ``file_path`` to completion, return success.
+
+    Thin wrapper over ``subprocess.run(build_playback_command(...))``. Never
+    raises — returns ``False`` on any failure (unsupported platform, missing
+    player binary, non-zero exit), matching the adapters' ``_play_audio_file``
+    contract. Callers needing barge-in should use ``build_playback_command``
+    directly with their own process handling.
+    """
+    try:
+        result = subprocess.run(
+            build_playback_command(file_path),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False

--- a/src/adapters/tts/elevenlabs_tts_adapter.py
+++ b/src/adapters/tts/elevenlabs_tts_adapter.py
@@ -14,6 +14,7 @@ import requests
 import re
 from pathlib import Path
 from typing import Optional, Dict, Any
+from adapters.audio.playback import build_playback_command
 
 class ElevenLabsTTS:
     """ElevenLabs TTS adapter with Penny personality integration"""
@@ -275,7 +276,7 @@ class ElevenLabsTTS:
                 # Start playing first chunk
                 try:
                     first_process = subprocess.Popen(
-                        ["afplay", first_audio],
+                        build_playback_command(first_audio),
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL
                     )
@@ -305,7 +306,7 @@ class ElevenLabsTTS:
                 # Start next chunk
                 try:
                     process = subprocess.Popen(
-                        ["afplay", audio_file],
+                        build_playback_command(audio_file),
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL
                     )
@@ -346,7 +347,7 @@ class ElevenLabsTTS:
         # Start playback (non-blocking for smooth transitions)
         try:
             process = subprocess.Popen(
-                ["afplay", audio_file],
+                build_playback_command(audio_file),
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL
             )

--- a/src/adapters/tts/google_tts_adapter.py
+++ b/src/adapters/tts/google_tts_adapter.py
@@ -1,6 +1,7 @@
 import os, tempfile, subprocess, threading, time
 import hashlib
 from pathlib import Path
+from adapters.audio.playback import build_playback_command
 from typing import Optional, Dict
 
 try:
@@ -107,9 +108,9 @@ class GoogleTTS:
     def _play_audio_file(self, file_path: str) -> bool:
         """Play audio file using system player."""
         try:
-            # Use afplay on macOS
+            # Cross-platform playback command (afplay/mpg123/ffplay by OS)
             process = subprocess.Popen(
-                ["afplay", file_path],
+                build_playback_command(file_path),
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL
             )

--- a/src/adapters/tts/streaming_elevenlabs_tts.py
+++ b/src/adapters/tts/streaming_elevenlabs_tts.py
@@ -15,6 +15,7 @@ import queue
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from adapters.audio.playback import build_playback_command
 
 class StreamingElevenLabsTTS:
     """Streaming ElevenLabs TTS adapter - generates chunks in parallel"""
@@ -152,7 +153,7 @@ class StreamingElevenLabsTTS:
             
         try:
             result = subprocess.run(
-                ["afplay", file_path],
+                build_playback_command(file_path),
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 timeout=15,

--- a/src/adapters/tts/streaming_tts_adapter.py
+++ b/src/adapters/tts/streaming_tts_adapter.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from queue import Queue, Empty
 from typing import Optional, Dict, Any, Callable
 import asyncio
+from adapters.audio.playback import build_playback_command
 
 try:
     from gtts import gTTS
@@ -223,7 +224,7 @@ class StreamingTTS:
                     # Play audio file
                     try:
                         process = subprocess.Popen(
-                            ['afplay', audio_file],
+                            build_playback_command(audio_file),
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.DEVNULL
                         )

--- a/tests/test_audio_playback.py
+++ b/tests/test_audio_playback.py
@@ -1,0 +1,78 @@
+"""Unit tests for the cross-platform audio-output helper (Phase 5 Week 14).
+
+Pure/mocked — no audio hardware needed. Locks the OS->command mapping and the
+loud-on-unknown-platform contract BEFORE the helper is wired into the TTS
+adapters. The adapters emit MP3, so each platform's command must be MP3-capable
+(afplay/mpg123/ffplay), not a PCM/WAV-only tool (aplay/paplay/winsound).
+"""
+import subprocess
+from unittest import mock
+
+import pytest
+
+from adapters.audio.playback import (
+    build_playback_command,
+    play_audio_file,
+    UnsupportedPlatformError,
+)
+
+FILE = "/tmp/example.mp3"
+
+
+def _patch_system(value):
+    return mock.patch("adapters.audio.playback.platform.system", return_value=value)
+
+
+class TestBuildPlaybackCommand:
+    def test_darwin_uses_afplay(self):
+        with _patch_system("Darwin"):
+            assert build_playback_command(FILE) == ["afplay", FILE]
+
+    def test_linux_uses_mpg123(self):
+        with _patch_system("Linux"):
+            assert build_playback_command(FILE) == ["mpg123", "-q", FILE]
+
+    def test_windows_uses_ffplay(self):
+        with _patch_system("Windows"):
+            assert build_playback_command(FILE) == [
+                "ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet", FILE,
+            ]
+
+    def test_unknown_platform_raises_naming_the_value(self):
+        with _patch_system("Plan9"):
+            with pytest.raises(UnsupportedPlatformError) as exc:
+                build_playback_command(FILE)
+        # the unresolved platform.system() value must appear in the message
+        assert "Plan9" in str(exc.value)
+
+
+class TestPlayAudioFile:
+    """Thin blocking wrapper: subprocess.run(build_playback_command(...)) -> bool."""
+
+    def test_returns_true_on_success(self):
+        with _patch_system("Darwin"), \
+                mock.patch("adapters.audio.playback.subprocess.run") as run:
+            run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+            assert play_audio_file(FILE) is True
+            run.assert_called_once()
+            # faithful: it plays exactly the built command
+            assert run.call_args.args[0] == ["afplay", FILE]
+
+    def test_returns_false_on_nonzero_returncode(self):
+        with _patch_system("Darwin"), \
+                mock.patch("adapters.audio.playback.subprocess.run") as run:
+            run.return_value = subprocess.CompletedProcess(args=[], returncode=1)
+            assert play_audio_file(FILE) is False
+
+    def test_returns_false_when_player_binary_missing(self):
+        # e.g. mpg123 not installed -> FileNotFoundError -> graceful False (soft)
+        with _patch_system("Linux"), \
+                mock.patch("adapters.audio.playback.subprocess.run",
+                           side_effect=FileNotFoundError):
+            assert play_audio_file(FILE) is False
+
+    def test_returns_false_on_unsupported_platform(self):
+        # convenience wrapper never raises: matches the adapters' _play_audio_file
+        # contract (loud signal lives in build_playback_command, tested above).
+        with _patch_system("Plan9"):
+            assert play_audio_file(FILE) is False


### PR DESCRIPTION
**Phase 5 Week 14's first slice** — abstract OS-specific audio playback with graceful degradation. Centralizes the playback command the 4 TTS adapters hardcoded as `["afplay", <file>]`.

### Why this shape
The adapters emit **MP3**, so each platform's command must be MP3-capable: **afplay** (macOS) / **mpg123** (Linux) / **ffplay** (Windows). The "obvious" stdlib options (`aplay`/`paplay`/`winsound`) are PCM/WAV-only and can't play the adapters' MP3 output — that's the key finding from the definition step.

### What's added
- **`src/adapters/audio/playback.py`**
  - `build_playback_command(file_path) -> list[str]` — OS→argv. Raises **`UnsupportedPlatformError`** (naming the unresolved `platform.system()` value) on unknown platforms — *loud*, so a missing port is obvious rather than a silent mute.
  - `play_audio_file(file_path) -> bool` — thin blocking convenience over `subprocess.run(build_playback_command(...))`; never raises (*soft*), matching the adapters' `_play_audio_file` contract. (Two-tier failure model: unknown OS → loud raise at the helper; known OS but player binary missing → runtime `FileNotFoundError` the callers already degrade to silence.)
- **`tests/test_audio_playback.py`** (8 tests, added to canonical `testpaths`) — written **before** the implementation. Pure/mocked, no hardware: per-OS argv, loud raise (naming the value) on unknown platform, and the wrapper's bool contract (success / nonzero exit / missing binary / unsupported platform).

### Adapter wiring — argv-only (faithful)
All 4 adapters (`google`, `elevenlabs`, `streaming_elevenlabs`, `streaming_tts`) now call `build_playback_command(x)` instead of the `["afplay", x]` literal. Each adapter's own logic is **completely untouched** — Popen/poll/terminate barge-in, `subprocess.run(timeout=15, check=True)`, and all `killall`/stop logic remain exactly as-is.

> **Deviation from the literal instruction, called out for review:** the task grouped `google` + `streaming_elevenlabs` as "delegate directly to `play_audio_file`." On inspection, **google's `_play_audio_file` has barge-in** (Popen + poll on `self._stop_playback`) and **streaming_elevenlabs uses `subprocess.run(timeout=15, check=True)`** — wholesale delegation to the generic blocking wrapper would silently drop barge-in / the timeout+check semantics. So I applied **argv-only** to all 4 to preserve behavior exactly (same faithful-move discipline as R1), and delivered `play_audio_file` as a tested standalone convenience. No behavior change anywhere.

### Explicitly deferred (separate follow-ups, NOT this PR)
- Stop/`killall` playback-interruption abstraction (macOS/Linux `killall` vs Windows `taskkill`).
- Calendar (`osascript`/AppleScript) cross-platform strategy.
- **VAD import guard** fix — kept out per instructions.

### Verification
- **8/8** new audio tests pass (no hardware — all mocked).
- **Canonical 451 → 459**: all original 451 still green + 8 new. *(The new pure unit tests belong in the canonical suite, so the count grew; nothing was removed or broken.)*
- **29/29** characterization `--run-slow` unaffected.
- **`research_first_pipeline.py` untouched** — `think()` and the pipeline are not part of this change.

One new module + one test file + 4 argv swaps + 1 `pytest.ini` line. Do **not** merge — leaving for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
