### PR TITLE
🛡️ Phase 5 Week 14 (slice 2): graceful import guard for WebRTC VAD adapter

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -35,6 +35,7 @@ testpaths =
     tests/test_user_model_enhancements.py
     tests/test_llm_registry.py
     tests/test_audio_playback.py
+    tests/test_vad_import_guard.py
 
 # Per-test timeout so a hung test (network/audio/LLM) can't stall the whole suite.
 # 'signal' method (vs 'thread') can interrupt blocking syscalls like a live

--- a/src/adapters/vad/webrtc_vad_adapter.py
+++ b/src/adapters/vad/webrtc_vad_adapter.py
@@ -1,5 +1,14 @@
 import sys
-import webrtcvad
+import logging
+
+try:
+    import webrtcvad
+    VAD_AVAILABLE = True
+except ImportError:
+    webrtcvad = None
+    VAD_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 # Python version compatibility check
 if sys.version_info >= (3, 13):
@@ -14,6 +23,15 @@ if sys.version_info >= (3, 13):
 class WebRTCVAD:
     def __init__(self, cfg: dict = None):
         self.cfg = cfg or {}
+        self.available = VAD_AVAILABLE
+        if not VAD_AVAILABLE:
+            # Degrade gracefully instead of crashing on import/instantiation.
+            logger.warning(
+                "webrtcvad unavailable; WebRTCVAD disabled "
+                "(callers can check .available / VAD_AVAILABLE)."
+            )
+            self.vad = None
+            return
         level = {"low": 0, "medium": 2, "high": 3}.get(self.cfg.get("sensitivity", "medium"), 2)
         self.vad = webrtcvad.Vad(level)
 

--- a/tests/test_vad_import_guard.py
+++ b/tests/test_vad_import_guard.py
@@ -1,0 +1,67 @@
+"""Import-guard tests for the WebRTC VAD adapter (Phase 5 Week 14, slice 2).
+
+Previously ``import webrtcvad`` sat unguarded at module top, so a missing or
+broken webrtcvad crashed the whole module on import — unlike the rest of the
+codebase, which degrades gracefully behind an ``*_AVAILABLE`` flag. These tests
+lock the graceful-degradation contract.
+
+Each case loads a FRESH copy of the adapter from source under a throwaway module
+name, so the shared cached ``adapters.vad.webrtc_vad_adapter`` is never mutated
+and other tests are unaffected. The "unavailable" cases simulate the missing
+dependency via ``sys.modules[{"webrtcvad": None}]`` (which makes
+``import webrtcvad`` raise ImportError) and need no real webrtcvad installed.
+"""
+import importlib.util
+import sys
+from unittest import mock
+
+import pytest
+
+import adapters.vad.webrtc_vad_adapter as _real_adapter
+
+ADAPTER_PATH = _real_adapter.__file__
+
+
+def _load_fresh(name: str, webrtcvad_present: bool):
+    spec = importlib.util.spec_from_file_location(name, ADAPTER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    if webrtcvad_present:
+        spec.loader.exec_module(mod)
+    else:
+        # None in sys.modules makes `import webrtcvad` raise ImportError.
+        with mock.patch.dict(sys.modules, {"webrtcvad": None}):
+            spec.loader.exec_module(mod)
+    return mod
+
+
+class TestWebrtcvadUnavailable:
+    """The dependency is missing/broken — must degrade, never crash."""
+
+    def test_module_imports_without_crashing(self):
+        mod = _load_fresh("vad_adapter_missing_import", webrtcvad_present=False)
+        assert mod.VAD_AVAILABLE is False
+
+    def test_adapter_instantiates_and_reports_unavailable(self):
+        mod = _load_fresh("vad_adapter_missing_init", webrtcvad_present=False)
+        vad = mod.WebRTCVAD()          # must NOT raise
+        assert vad.available is False  # reports itself unavailable
+        assert vad.vad is None         # no backend object built
+
+    def test_is_speech_does_not_crash_when_unavailable(self):
+        # is_speech is a pre-existing stub (flagged separately) that doesn't use
+        # self.vad; assert only that the degraded adapter doesn't crash calling it.
+        mod = _load_fresh("vad_adapter_missing_isspeech", webrtcvad_present=False)
+        vad = mod.WebRTCVAD()
+        assert vad.is_speech(b"") is False
+
+
+class TestWebrtcvadAvailable:
+    """Normal path — no regression when the dependency is installed."""
+
+    def test_available_path_builds_backend(self):
+        pytest.importorskip("webrtcvad")
+        mod = _load_fresh("vad_adapter_present", webrtcvad_present=True)
+        assert mod.VAD_AVAILABLE is True
+        vad = mod.WebRTCVAD()
+        assert vad.available is True
+        assert vad.vad is not None      # real webrtcvad.Vad constructed


### PR DESCRIPTION
**Phase 5 Week 14's second slice.** Makes `src/adapters/vad/webrtc_vad_adapter.py` degrade gracefully when its optional dependency is missing.

### The problem
`import webrtcvad` sat **unguarded at module top**, so a missing or broken webrtcvad (recall the `setuptools<81`/`pkg_resources` fragility) raised `ImportError` and **crashed the whole module on import** — inconsistent with the rest of the codebase, which guards optional deps behind an `*_AVAILABLE` flag (gtts, pyttsx3, gptoss, reasoning_detector).

### The fix (matches existing convention)
- `try: import webrtcvad; VAD_AVAILABLE = True / except ImportError: webrtcvad = None; VAD_AVAILABLE = False`.
- `WebRTCVAD.__init__` no longer crashes when unavailable: it sets `self.available`, logs a warning, and sets `self.vad = None` instead of calling `webrtcvad.Vad()`.
- **Callers handle it:** `create_vad_engine()` and `SimpleVAD()` now instantiate without crashing and can check `.available` / `VAD_AVAILABLE` (verified end-to-end with webrtcvad simulated-absent — the chain returns a degraded engine reporting `available=False` rather than throwing).

### Tests first (TDD)
`tests/test_vad_import_guard.py` (4 tests, added to canonical `testpaths`), written before the fix. Each loads a **fresh copy of the adapter from source under a throwaway module name**, so the shared cached module is never mutated and no other test is affected. The "unavailable" cases simulate the missing dep via `sys.modules["webrtcvad"] = None` (makes `import webrtcvad` raise) and need no real webrtcvad; the "available" case uses `importorskip` for no-regression.

### ⚠️ Separate follow-up, NOT fixed here (flagged as requested)
- **`is_speech()` is a stub.** It currently returns `len(audio_bytes) > 160` and **never uses the real `self.vad` object** — so VAD isn't actually doing voice-activity detection, just a length heuristic. This is a **pre-existing behavioral quirk**, distinct from the import-crash fixed here. Left **byte-identical** in this PR (confirmed via diff); it deserves its own change to wire the real `webrtcvad.Vad.is_speech(frame, sample_rate)` with correct frame sizing.
- **Related (not in scope):** `src/audio/listener.py` also has an unguarded top-level `import webrtcvad` — same class of issue in a different module; a candidate for the same treatment later.

### Verification
- **4/4** new tests pass (unavailable path needs no hardware/dep; available path importorskips).
- **Canonical 459 → 463**: all prior 459 still green + 4 new.
- **29/29** characterization `--run-slow` unaffected.
- **`research_first_pipeline.py` untouched** — this doesn't touch `think()` or the pipeline.

One adapter file + one test file + 1 `pytest.ini` line. Do **not** merge — leaving for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
