### PR TITLE
🩹 Fix follow-up #7: loosen flaky Hebbian timing thresholds for shared CI

### DIFF
--- a/tests/test_hebbian_integration.py
+++ b/tests/test_hebbian_integration.py
@@ -215,7 +215,19 @@ class TestPerformance:
     """Test performance requirements"""
 
     def test_vocab_observation_latency(self, vocab_associator):
-        """Test: Vocabulary observation < 3ms"""
+        """Test: Vocabulary observation. Real target <3ms (local median ~1.4ms).
+
+        The assert below is a loose guard against GROSS regressions on shared
+        CI runners, not the performance target. These are ~1ms SQLite writes;
+        under disk contention on GitHub's shared runners this class of op has
+        been observed spiking to ~45ms (~100x its local cost) on a run only
+        ~3.6x slower in aggregate — so per-op I/O variance far exceeds the
+        aggregate slowdown. 250ms = ~5.5x the worst value observed in CI, and
+        still ~150-800x the real op cost, so a genuine regression (a sleep, a
+        full-table scan, per-element I/O) fails while runner noise does not.
+        Local stress-testing can't reproduce this shared-runner I/O contention,
+        so the margin is set against observed CI values. See follow-up #7.
+        """
         message = "ngl this is a test message for performance tbh"
 
         start = time.time()
@@ -223,7 +235,7 @@ class TestPerformance:
             vocab_associator.observe_conversation(message, "casual_chat")
         elapsed = (time.time() - start) / 10 * 1000  # ms per observation
 
-        assert elapsed < 10, f"Vocab observation too slow: {elapsed:.2f}ms"
+        assert elapsed < 250, f"Vocab observation too slow: {elapsed:.2f}ms"
 
     def test_dim_observation_latency(self, dim_associator):
         """Test: Dimension observation < 3ms"""
@@ -238,7 +250,9 @@ class TestPerformance:
             dim_associator.observe_activations(dims)
         elapsed = (time.time() - start) / 10 * 1000  # ms per observation
 
-        assert elapsed < 10, f"Dim observation too slow: {elapsed:.2f}ms"
+        # Loose CI guard, not the target (real target <3ms, local median ~0.3ms).
+        # Worst observed on a loaded shared runner: ~45ms. 250ms = ~5.5x that.
+        assert elapsed < 250, f"Dim observation too slow: {elapsed:.2f}ms"
 
     def test_vocab_query_latency(self, vocab_associator):
         """Test: Vocabulary query < 1ms"""
@@ -250,7 +264,10 @@ class TestPerformance:
             vocab_associator.get_association_strength("test", "casual_chat")
         elapsed = (time.time() - start) / 100 * 1000  # ms per query
 
-        assert elapsed < 5, f"Vocab query too slow: {elapsed:.2f}ms"
+        # Loose CI guard, not the target (real target <1ms, local ~0.13ms). This
+        # sibling hasn't flaked yet, but its <5ms wall-clock assert is the same
+        # class of shared-runner fragility, so it's loosened alongside the others.
+        assert elapsed < 250, f"Vocab query too slow: {elapsed:.2f}ms"
 
     def test_dim_prediction_latency(self, dim_associator):
         """Test: Dimension prediction < 3ms"""
@@ -269,7 +286,9 @@ class TestPerformance:
             )
         elapsed = (time.time() - start) / 10 * 1000  # ms per prediction
 
-        assert elapsed < 10, f"Dim prediction too slow: {elapsed:.2f}ms"
+        # Loose CI guard, not the target (real target <3ms, local ~0.1ms). Same
+        # shared-runner fragility class as the others; loosened for consistency.
+        assert elapsed < 250, f"Dim prediction too slow: {elapsed:.2f}ms"
 
 
 class TestDataPersistence:

--- a/tests/test_hebbian_manager.py
+++ b/tests/test_hebbian_manager.py
@@ -541,8 +541,13 @@ class TestPerformance:
             latencies.append(result['latency_ms'])
 
         avg_latency = sum(latencies) / len(latencies)
-        # Should be under 10ms on average (our target)
-        assert avg_latency < 50  # Be generous for CI environments
+        # Real target: <10ms average (a full conversation turn). The assert is a
+        # loose guard against GROSS regressions on shared CI, not the target: the
+        # earlier "generous" 50ms was still too tight — this test has been
+        # observed at 52-58ms under runner disk contention. 300ms = ~5x the
+        # worst observed, still 30x the real target, so a genuine regression
+        # fails while runner noise does not. See follow-up #7.
+        assert avg_latency < 300
 
     def test_cache_refresh_interval(self, manager):
         """Test: Cache refreshes at configured interval"""


### PR DESCRIPTION
Fixes consolidated follow-up **#7** — the Hebbian `TestPerformance` latency tests that keep flaking on GitHub's shared runners (measured **29 / 45 / 58 ms** against 10ms/50ms thresholds).

### 1. Were the thresholds deliberate? — No, they're loose guards
`git blame` + the docstrings show the assert values are **loose guardrails over the real performance targets**, not tuned regression detectors:
- docstrings state the real targets (`<3ms` observation, `<1ms` query, `<10ms` manager turn);
- the asserts were set 3–5× looser at the original Week 9 (`526d61e`) / Week 10 (`94d9fd2`) commits and never tuned since;
- the manager one already carried `# Be generous for CI environments` — an earlier CI-variance bump that was **still too tight**.

They were never chosen to catch a regression at exactly 10/50ms.

### 2. Chosen fix: loosen (option a), not move to `--run-slow` (option b)
`--run-slow` gating is **file-level** (`SLOW_FILES` is a set of filenames), so relocating these would exile the *entire* `test_hebbian_integration.py` / `test_hebbian_manager.py` files — which contain many real functional tests — from CI. Splitting them into a new slow file "works," but **`--run-slow` never runs in CI**, so that just *deletes* the regression signal instead of moving it. Loosening keeps a gross-regression signal in CI while ending the flakiness.

**Tradeoff:** a loose threshold only catches *gross* (100×+) regressions, not subtle ones. But subtle perf regressions are undetectable on shared runners anyway (see §4), so nothing real is lost.

### 3. New thresholds — evidence-based, not arbitrary
I measured the real local latencies (25 trials): observations ~1.4ms/0.3ms, query ~0.13ms, prediction ~0.1ms. The key insight from the CI logs: dim_observation hit **45ms (~100× its local baseline)** on a run only ~3.6× slower in aggregate — so per-op I/O spikes far exceed the aggregate slowdown. Thresholds set at **~5.5× the worst value observed in CI**:

| Test(s) | Old | New | Rationale |
|---|---|---|---|
| vocab/dim observation, vocab query, dim prediction | `<10` / `<5` | **`<250`** | ~5.5× the ~45ms worst-observed; still 150–800× the ~1ms real op cost |
| manager avg turn latency | `<50` | **`<300`** | ~5× the 58ms worst-observed; still 30× the 10ms target |

A genuine regression (a sleep, a full-table scan, per-element I/O) still fails; runner noise does not.

### Scope note
The reported flakes were 3 tests. I **also** loosened the 2 same-class siblings in that file (`vocab_query` `<5`, `dim_prediction` `<10`) — they hadn't flaked *yet* but are the identical shared-runner-fragility pattern (the `<5ms` one is the most at-risk of all). Flagged here as a deliberate, separable extension — drop it if you'd rather keep this to the exact 3.

### 4. Verification (and an honest limitation)
- **25 consecutive local runs** of all 5 tests → 25/25 pass.
- Full canonical suite unchanged (**463 passed**); only threshold numbers changed, no tests added/removed.
- **Limitation:** my local machine can't reproduce shared-runner I/O contention — under 8-core CPU saturation + disk churn the latencies still stayed ~2ms (fast SSD/cores absorb it). So the margin is deliberately set against the **worst values observed in real CI**, not local stress. If it ever flakes again, the numbers should move up further, not the tests be re-diagnosed.

Two test files, threshold + comment changes only. Do **not** merge — leaving for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
